### PR TITLE
Fix npm start on Windows by passing /k to cmd

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -123,7 +123,7 @@ function series(scripts) {
 
 function startInNewWindow(command) {
   return isWindows ?
-    `start cmd.exe @cmd \\k "cd ${__dirname} && ${command}"` :
+    `start cmd \/k "cd ${__dirname} && ${command}"` :
     [
       `osascript`,
       `-e 'tell application "Terminal"'`,


### PR DESCRIPTION
Tiny issue, windows (usually) likes forward slashes in command line parameters. Not sure what the `@cmd` was doing but this should sort it out :)