### PR TITLE
Stub route without data for wait alias

### DIFF
--- a/cypress/e2e/users_spec.js
+++ b/cypress/e2e/users_spec.js
@@ -58,6 +58,8 @@ describe('Users', () => {
       const newBio = 'a new bio'
       const newEmail = `${user.username}_55@example.com`
       cy
+        .server()
+        .route('PUT', `${Cypress.env('API_URL')}/user`).as('putUser')
         .get(sel('profile-url'))
         .type(photoUrl)
         .get(sel('username'))
@@ -73,7 +75,7 @@ describe('Users', () => {
         .get('form')
         .submit()
 
-      cy.wait(500)
+      cy.wait('@putUser')
 
       visitApp('/settings')
 


### PR DESCRIPTION
Adding arbitrary wait times is considered by Cypress to be an anti-pattern https://docs.cypress.io/docs/anti-patterns#section-adding-unncessary-waits

So stubbing this route without a fixture will allow it to pass through, but still have the alias to wait on.

Depending on how deep this gets, and considering these'll probably all be pass-through.. you might want to setup your route aliases in a command called by `visitApp` to keep it simple.