### PR TITLE
WIP: Add basic vagrant provisioining

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    # Start with base vagrant box. This one is only 271 MB in size.
+    config.vm.box = "bento/ubuntu-16.04"
+
+    # Create forwarding ports for client-guest machine access via localhost.
+    # auto_correct allows the simultaneous spin up of multiple VM locally.
+    config.vm.network :forwarded_port, guest: 8080, host: 8080, auto_correct: true
+    config.vm.network :forwarded_port, guest: 27017, host: 27017, auto_correct: true
+    config.vm.network :forwarded_port, guest: 27018, host: 27018, auto_correct: true
+
+    # Add the tty fix as mentioned in issue 1673 on vagrant repo
+    # To avoid 'stdin is not a tty' messages
+    # vagrant provisioning in shell runs bash -l
+    config.vm.provision "fix-no-tty", type: "shell" do |s|
+        s.privileged = false
+        s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+    end
+
+    # Provision the virtual machine.
+    config.vm.provision :shell, :path => "provision.sh"
+end
+0

--- a/provision.sh
+++ b/provision.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# set up error reporting when piping
+set -eou pipefail
+
+apt-add-repository ppa:git-core/ppa
+apt-key adv \
+  --keyserver hkp://keyserver.ubuntu.com:80 \
+  --recv 0C49F3730359A14518585931BC711F9BA15703C6
+echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+
+apt-get update -y
+apt-get install -y \
+ libssl-dev \
+ build-essential \
+ git-all \
+ curl \
+ vim \
+ mongodb-org
+
+su - vagrant << NVM
+# install nvm
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash > /dev/null
+# activate nvm
+source ~/.nvm/nvm.sh > /dev/null 2>&1
+# install node 6
+nvm install v6 > /dev/null 2>&1
+nvm alias default v6
+# add yarn
+curl -o- -L https://yarnpkg.com/install.sh | bash
+NVM


### PR DESCRIPTION
- [X] Vagrant provisioning
- [X] git
- [X] Node
- [X] Yarn & NVM
- [X] MongoDB
- [ ] Cypress
- [ ] Test on Windows

## How to test
- ` git checkout` the PR
- install VirtualBox and Vagrant (`brew cask install virtualbox vagrant`)
- run `vagrant up` in the root directory of the project, which has the `Vagrantfile`. This would take about 6 m (on OSX 10) to provision the Ubuntu box. On Windows, this may be closer to 10 mins.
- log into the vagrant box with `vagrant ssh`
- check versions of `git`, `node`, `mongo`
- set Mongo Path. Will add it to provisioning later.
- go to `/vagrant` with `cd /vagrant`. This directory is shared by default with your project. Vagrant does it by default.
- Run `yarn setup`. This would be running inside the Ubuntu machine. Might give some error related to Cypress install.
