### PR TITLE
Change redux-logger to {redux-logger}

### DIFF
--- a/client/src/store.js
+++ b/client/src/store.js
@@ -1,5 +1,5 @@
 import {applyMiddleware, createStore} from 'redux'
-import createLogger from 'redux-logger'
+import {createLogger} from 'redux-logger'
 import {promiseMiddleware, localStorageMiddleware} from './middleware'
 import reducer from './reducer'
 


### PR DESCRIPTION
Redux logger no longer exports by default, need to use object
destructuring.