### PR TITLE
fix typo in `toMatchObject` example

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -114,7 +114,7 @@ successful for this workshop
   `expect({a: {b: 'c'}, d: 'e'}).toEqual({a: {b: 'c'}, d: 'e'})`
 * [`toMatchObject`](https://facebook.github.io/jest/docs/en/expect.html#tomatchobjectobject)
   is similar to `toEqual`, but for partial equality:
-  `expect({a: {b: 'c'}, d: 'e'}).toEqual({d: 'e'})`
+  `expect({a: {b: 'c'}, d: 'e'}).toMatchObject({d: 'e'})`
 * [`toHaveBeenCalledTimes`](https://facebook.github.io/jest/docs/en/expect.html#tohavebeencalledtimesnumber)
   is a jest mock function (`jest.fn()`) assertion:
   `expect(mockFn).toHaveBeenCalledTimes(0)`


### PR DESCRIPTION
fix copy & paste error which resulted in using the incorrect assertion.