### PR TITLE
chore: ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules
+package-lock.json
 coverage
 build
 .DS_Store


### PR DESCRIPTION
Running `npm run setup` will generate `package-lock.json` in `calculator` and `calculator.solution` for npm5, it is kind of annoying and better add into ignore file