### PR TITLE
add testURL to jestConfig

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   coverageDirectory: './coverage',
+  testURL: 'http://localhost',
   collectCoverageFrom: [
     '**/src/**/*.js',
     '!**/__tests__/**',

--- a/other/configuration/calculator.solution/jest.config.js
+++ b/other/configuration/calculator.solution/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   displayName: 'calculator',
   testEnvironment: 'jsdom',
+  testURL: 'http://localhost',
   setupTestFrameworkScriptFile: require.resolve(
     './test/setup-test-framework.js',
   ),

--- a/other/jest-expect/jest.config.js
+++ b/other/jest-expect/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   displayName: 'expect',
+  testURL: 'http://localhost',
 }

--- a/other/simple-react/jest.config.js
+++ b/other/simple-react/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   displayName: 'react',
+  testURL: 'http://localhost',
 }

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,6 +1,7 @@
 // ./server/jest.config.js
 module.exports = {
   displayName: 'server',
+  testURL: 'http://localhost',
   testEnvironment: 'node',
   modulePaths: ['<rootDir>/src', '<rootDir>/test'],
 }


### PR DESCRIPTION
Fixes  `SecurityError: localStorage is not available for opaque origins`. See issue #90 