### PR TITLE
update jest.config

### DIFF
--- a/other/whats-a-test/jest.config.js
+++ b/other/whats-a-test/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   testMatch: ['**/4.js'],
+  testEnvironment: "node"
 }


### PR DESCRIPTION
Running ./other/whats-a-test/jest in node/13.9.0 causes error 
 FAIL  ./5.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins
      
      at Window.get localStorage [as localStorage] (../../node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)